### PR TITLE
Update toml & shield from future toml changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netlify_toml"
-version = "0.2.8"
+version = "0.3.0"
 authors = ["David Calavera <david.calavera@gmail.com>"]
 license = "MIT"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ homepage = "https://github.com/calavera/netlify-toml-rs"
 [dependencies]
 serde = "1.0"
 serde_derive = "1.0"
-toml = "0.4.9"
+toml = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,9 @@ pub struct Template {
     pub environment: Option<HashMap<String, String>>,
 }
 
+/// Base crate error type
+pub type Error = toml::de::Error;
+
 /// Parses the contents of a netlify.toml file as a Config structure.
 ///
 /// # Arguments
@@ -87,7 +90,7 @@ pub struct Template {
 ///
 /// let result = netlify_toml::from_str(io);
 /// ```
-pub fn from_str(io: &str) -> Result<Config, toml::de::Error> {
+pub fn from_str(io: &str) -> Result<Config, Error> {
     toml::from_str::<Config>(io)
 }
 


### PR DESCRIPTION
This change allows consumers to use this crate's `Error` type without taking a dependency on a specific version of `toml`. It also updates `toml` to the 0.5 minor version ([changes](https://github.com/alexcrichton/toml-rs/compare/0.4.9...0.5.6)).