### PR TITLE
feat: Continue allowing parsing old-style edge handlers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,8 @@ pub struct Redirect {
     pub query: Option<HashMap<String, String>>,
     pub conditions: Option<HashMap<String, HashSet<String>>>,
     pub signed: Option<String>,
+    #[serde(alias = "edge-handler")]
+    pub edge_handler: Option<String>,
 }
 
 /// Header holds information to add response headers for a give url.
@@ -245,6 +247,7 @@ impl Default for Redirect {
             conditions: None,
             query: None,
             headers: None,
+            edge_handler: None,
         }
     }
 }
@@ -271,6 +274,7 @@ mod tests {
             query: None,
             conditions: None,
             signed: None,
+            edge_handler: None,
         };
 
         let r2 = Redirect {
@@ -282,6 +286,7 @@ mod tests {
             query: None,
             conditions: None,
             signed: None,
+            edge_handler: None,
         };
         assert_eq!(r, r2)
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -39,7 +39,7 @@ for = "/foo"
     );
 
     let context = config.context.unwrap();
-    let ref prod = context.get("production").unwrap();
+    let prod = context.get("production").unwrap();
     if let Some(ref cmd) = prod.command {
         assert_eq!(cmd, &String::from("make prod"));
     }
@@ -84,7 +84,7 @@ for = "/foo"
 
     let result = netlify_toml::from_str(&io);
     match result {
-        Ok(v) => assert!(false, "unexpected config: {:?}", v),
+        Ok(v) => panic!("unexpected config: {:?}", v),
         Err(e) => println!("error parsing headers: {:?}", e),
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -142,6 +142,7 @@ fn test_full_redirect_rules() {
   conditions = {Language = ["en"], Country = ["US"], Role = ["admin"]}
   headers = {X-From = "Netlify"}
   signed = "API_SIGNATURE_TOKEN"
+  edge-handler = "hello-world"
     "#;
 
     let config = netlify_toml::from_str(&io).unwrap();
@@ -154,6 +155,7 @@ fn test_full_redirect_rules() {
     assert_eq!("API_SIGNATURE_TOKEN", redirect.signed.unwrap());
     assert_eq!(302, redirect.status);
     assert_eq!(true, redirect.force);
+    assert_eq!("hello-world", redirect.edge_handler.unwrap());
 
     let query = redirect.query.unwrap();
     assert_eq!(1, query.len());


### PR DESCRIPTION
We might need the parser in bitballoon to still work with old-style redirect-based edge handlers.